### PR TITLE
added launchpad x support

### DIFF
--- a/lss/devices/__init__.py
+++ b/lss/devices/__init__.py
@@ -1,5 +1,6 @@
 from lss.devices.launchpad_mini_3 import LaunchpadMiniMk3
+from lss.devices.launchpad_x import LaunchpadX
 
-DEVICES = {LaunchpadMiniMk3.name: LaunchpadMiniMk3}
+DEVICES = {LaunchpadMiniMk3.name: LaunchpadMiniMk3, LaunchpadX.name: LaunchpadX}
 
 DEVICES_NAMES = DEVICES.keys()

--- a/lss/devices/launchpad_x.py
+++ b/lss/devices/launchpad_x.py
@@ -1,0 +1,13 @@
+from lss.devices.launchpad_base import BaseLaunchpad
+from lss.midi import HexMessage
+
+
+class LaunchpadX(BaseLaunchpad):
+    row_count = 9
+    column_count = 9
+
+    name = "Launchpad X LPX MIDI"
+
+    def hand_shake(self):
+        self._outport.send(HexMessage("240 0 32 41 2 12 0 127 247"))
+        self._outport.send(HexMessage("2400 32 41 2 12 14 1 247"))


### PR DESCRIPTION
launchpad_x.py has the LaunchpadX class
same as the LaunchpadMiniMk3 except for the name and handshake.
I imported it into devices/__init__  and added it to the DEVICES dictionary.

I tested with my launchpad x and it worked.